### PR TITLE
improvements to sentinel

### DIFF
--- a/sentinel/auth.go
+++ b/sentinel/auth.go
@@ -1,26 +1,25 @@
 package sentinel
 
 import (
-	"arkeo/common"
-	"arkeo/common/cosmos"
-	"arkeo/x/arkeo/types"
 	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
+	"time"
+
+	"arkeo/common"
+	"arkeo/common/cosmos"
+	"arkeo/x/arkeo/types"
 
 	"golang.org/x/time/rate"
 )
 
 const (
-	QueryHeight  = "__cheight"
-	QueryNonce   = "__nonce"
-	QuerySpender = "__spender"
-	QuerySig     = "__signature"
-	QueryChain   = "__chain"
+	QueryArkAuth = "arkauth"
 )
 
 // Create a map to hold the rate limiters for each visitor and a mutex.
@@ -29,32 +28,75 @@ var (
 	mu       sync.Mutex
 )
 
+type ArkAuth struct {
+	Provider  common.PubKey
+	Chain     common.Chain
+	Spender   common.PubKey
+	Height    int64
+	Nonce     int64
+	Signature []byte
+}
+
+func parseArkAuth(raw string) (ArkAuth, error) {
+	var aa ArkAuth
+	var err error
+
+	parts := strings.SplitN(raw, ":", 6)
+	if len(parts) != 6 {
+		return aa, fmt.Errorf("Not properly formatted ark-auth string: %s\n", raw)
+	}
+	aa.Provider, err = common.NewPubKey(parts[0])
+	if err != nil {
+		return aa, err
+	}
+	aa.Chain, err = common.NewChain(parts[1])
+	if err != nil {
+		return aa, err
+	}
+	aa.Spender, err = common.NewPubKey(parts[2])
+	if err != nil {
+		return aa, err
+	}
+	aa.Height, err = strconv.ParseInt(parts[3], 10, 64)
+	if err != nil {
+		return aa, err
+	}
+	aa.Nonce, err = strconv.ParseInt(parts[4], 10, 64)
+	if err != nil {
+		return aa, err
+	}
+	aa.Signature, err = hex.DecodeString(parts[5])
+	if err != nil {
+		return aa, err
+	}
+	return aa, nil
+}
+
+func (aa ArkAuth) Validate(provider common.PubKey) error {
+	creator, err := provider.GetMyAddress()
+	if err != nil {
+		return fmt.Errorf("Internal Server Error: %s", err)
+	}
+	if !provider.Equals(aa.Provider) {
+		return fmt.Errorf("provider pubkey does not match provider")
+	}
+	msg := types.NewMsgClaimContractIncome(creator.String(), aa.Provider, aa.Chain.String(), aa.Spender, aa.Nonce, aa.Height, aa.Signature)
+	return msg.ValidateBasic()
+}
+
 func (p Proxy) auth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		var aa ArkAuth
+
 		args := r.URL.Query()
+		raw, aaOK := args[QueryArkAuth]
+		if aaOK {
+			aa, err = parseArkAuth(raw[0])
+		}
 
-		// check if request has auth args
-		height, heightOK := args[QueryHeight]
-		nonce, nonceOK := args[QueryNonce]
-		spender, spenderOK := args[QuerySpender]
-		chain, chainOK := args[QueryChain]
-		sig, sigOK := args[QuerySig]
-
-		if heightOK && nonceOK && spenderOK && chainOK && sigOK {
-			nonceInt, err := strconv.ParseInt(nonce[0], 10, 64)
-			if err != nil {
-				log.Print(err.Error())
-				http.Error(w, "Invalid nonce", http.StatusBadRequest)
-				return
-			}
-			heightInt, err := strconv.ParseInt(height[0], 10, 64)
-			if err != nil {
-				log.Print(err.Error())
-				http.Error(w, "Invalid nonce", http.StatusBadRequest)
-				return
-			}
-
-			httpCode, err := p.paidTier(heightInt, nonceInt, chain[0], spender[0], sig[0])
+		if err != nil || aa.Validate(p.Config.ProviderPubKey) != nil {
+			httpCode, err := p.paidTier(aa, r.RemoteAddr)
 			if err != nil {
 				log.Println(err.Error())
 				http.Error(w, err.Error(), httpCode)
@@ -79,87 +121,29 @@ func (p Proxy) freeTier(remoteAddr string) (int, error) {
 		return http.StatusInternalServerError, fmt.Errorf("Internal Server Error: %s", err)
 	}
 
-	mu.Lock()
-	defer mu.Unlock()
-
-	limiter, exists := visitors[key]
-	if !exists {
-		limiter = rate.NewLimiter(rate.Every(p.Config.FreeTierRateLimitDuration), p.Config.FreeTierRateLimit)
-		visitors[key] = limiter
-	}
-
-	if !limiter.Allow() {
+	if ok := p.isRateLimited(key, -1); ok {
 		return http.StatusTooManyRequests, fmt.Errorf(http.StatusText(429))
 	}
 
 	return http.StatusOK, nil
 }
 
-func (p Proxy) paidTier(height, nonce int64, chain, spender, signature string) (int, error) {
-	creator, err := p.Config.ProviderPubKey.GetMyAddress()
-	if err != nil {
-		return http.StatusInternalServerError, fmt.Errorf("Internal Server Error: %s", err)
-	}
-
-	spenderPK, err := common.NewPubKey(spender)
-	if err != nil {
-		return http.StatusBadRequest, fmt.Errorf("Invalid spender pubkey")
-	}
-
-	sig, err := hex.DecodeString(signature)
-	if err != nil {
-		return http.StatusBadRequest, fmt.Errorf("unable to decode signature")
-	}
-
-	msg := types.NewMsgClaimContractIncome(creator.String(), p.Config.ProviderPubKey, chain, spenderPK, nonce, height, sig)
-	if err := msg.ValidateBasic(); err != nil {
-		return http.StatusBadRequest, fmt.Errorf("bad claim: %s", err)
-	}
-
-	contractKey := p.MemStore.Key(p.Config.ProviderPubKey.String(), chain, spender)
-	contract, err := p.MemStore.Get(contractKey)
-	if err != nil {
-		return http.StatusInternalServerError, fmt.Errorf("Internal Server Error: %s", err)
-	}
-
-	if contract.IsClose(p.MemStore.GetHeight()) {
-		return http.StatusPaymentRequired, fmt.Errorf("open a contract")
-	}
-
-	chainInt, err := common.NewChain(chain)
-	if err != nil {
-		return http.StatusInternalServerError, fmt.Errorf("Internal Server Error: %s", err)
-	}
-
-	key := fmt.Sprintf("%d-%s", chainInt, spender)
-
-	claim := NewClaim(p.Config.ProviderPubKey, chainInt, spenderPK, nonce, height, signature)
-	if p.ClaimStore.Has(key) {
-		var err error
-		claim, err = p.ClaimStore.Get(key)
-		if err != nil {
-			return http.StatusInternalServerError, fmt.Errorf("Internal Server Error: %s", err)
-		}
-		if claim.Height == height && contract.Height == height && claim.Nonce >= nonce {
-			return http.StatusBadRequest, fmt.Errorf("bad nonce (%d/%d)", nonce, claim.Nonce)
-		}
-	}
-
-	// check if we've exceed the total number of pay-as-you-go queries
-	if contract.Type == types.ContractType_PayAsYouGo {
-		if contract.Deposit.LT(cosmos.NewInt(nonce * contract.Rate)) {
-			return http.StatusPaymentRequired, fmt.Errorf("open a contract")
-		}
-	}
-
+func (p Proxy) isRateLimited(key string, ctype types.ContractType) bool {
 	mu.Lock()
 	defer mu.Unlock()
 
-	limitTokens := p.Config.SubTierRateLimit
-	limitDuration := p.Config.SubTierRateLimitDuration
-	if contract.Type == types.ContractType_PayAsYouGo {
+	var limitTokens int
+	var limitDuration time.Duration
+	switch ctype {
+	case types.ContractType_Subscription:
+		limitTokens = p.Config.SubTierRateLimit
+		limitDuration = p.Config.SubTierRateLimitDuration
+	case types.ContractType_PayAsYouGo:
 		limitTokens = p.Config.AsGoTierRateLimit
 		limitDuration = p.Config.AsGoTierRateLimitDuration
+	default:
+		limitTokens = p.Config.FreeTierRateLimit
+		limitDuration = p.Config.FreeTierRateLimitDuration
 	}
 
 	limiter, exists := visitors[key]
@@ -168,19 +152,63 @@ func (p Proxy) paidTier(height, nonce int64, chain, spender, signature string) (
 		visitors[key] = limiter
 	}
 
-	if !limiter.Allow() {
+	return !limiter.Allow()
+}
+
+func (p Proxy) paidTier(aa ArkAuth, remoteAddr string) (int, error) {
+	contractKey := p.MemStore.Key(aa.Provider.String(), aa.Chain.String(), aa.Spender.String())
+	contract, err := p.MemStore.Get(contractKey)
+	if err != nil {
+		if contract.IsEmpty() {
+			// user queried for a non-existent contract. Marking the request
+			// against their free tier so they don't thrash daemon with
+			// random/fake requests
+			return p.freeTier(remoteAddr)
+		} else {
+			return http.StatusInternalServerError, fmt.Errorf("Internal Server Error: %s", err)
+		}
+	}
+
+	if contract.IsClose(p.MemStore.GetHeight()) {
+		return http.StatusPaymentRequired, fmt.Errorf("open a contract")
+	}
+
+	key := fmt.Sprintf("%d-%s", aa.Chain, aa.Spender)
+	sig := hex.EncodeToString(aa.Signature)
+
+	claim := NewClaim(aa.Provider, aa.Chain, aa.Spender, aa.Nonce, aa.Height, sig)
+	if p.ClaimStore.Has(key) {
+		var err error
+		claim, err = p.ClaimStore.Get(key)
+		if err != nil {
+			return http.StatusInternalServerError, fmt.Errorf("Internal Server Error: %s", err)
+		}
+		if claim.Height == aa.Height && contract.Height == aa.Height && claim.Nonce >= aa.Nonce {
+			return http.StatusBadRequest, fmt.Errorf("bad nonce (%d/%d)", aa.Nonce, claim.Nonce)
+		}
+	}
+
+	// check if we've exceed the total number of pay-as-you-go queries
+	if contract.Type == types.ContractType_PayAsYouGo {
+		if contract.Deposit.LT(cosmos.NewInt(aa.Nonce * contract.Rate)) {
+			return http.StatusPaymentRequired, fmt.Errorf("open a contract")
+		}
+	}
+
+	if ok := p.isRateLimited(key, contract.Type); ok {
+		fmt.Println("GOT HEREz")
 		return http.StatusTooManyRequests, fmt.Errorf(http.StatusText(429))
 	}
 
-	claim.Nonce = nonce
-	claim.Height = height
-	claim.Signature = signature
+	claim.Nonce = aa.Nonce
+	claim.Height = aa.Height
+	claim.Signature = sig
 	claim.Claimed = false
 	if err := p.ClaimStore.Set(claim); err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("Internal Server Error: %s", err)
 	}
-	contract.Nonce = nonce
-	contract.Height = height
+	contract.Nonce = aa.Nonce
+	contract.Height = aa.Height
 	p.MemStore.Put(contractKey, contract)
 
 	return http.StatusOK, nil

--- a/sentinel/memstore.go
+++ b/sentinel/memstore.go
@@ -49,6 +49,10 @@ func (k *MemStore) Get(key string) (types.Contract, error) {
 }
 
 func (k *MemStore) Put(key string, value types.Contract) {
+	if value.IsClose(k.blockHeight) {
+		delete(k.db, key)
+		return
+	}
 	k.db[key] = value
 }
 


### PR DESCRIPTION
1) sentinel now filters contract/claims based on its own pubkey. should reduce resource demands
2) contracts auto get deleted from memory when they expire so we don't have a "memory leak"
3) Thrashing sentinel with authenticated but bogus requests get rate limited as well
4) switched authenticated from multiple query args to a single query arg (`arkauth`). Headers don't allow enough space to be used, therefore, query arg is our best option. The special formatted string does need to be url encoded (since it uses `:`, in the string)