### PR TITLE
fix: pay-as-you-go client/provider rate validation

### DIFF
--- a/x/arkeo/keeper/msg_server_open_contract.go
+++ b/x/arkeo/keeper/msg_server_open_contract.go
@@ -78,7 +78,7 @@ func (k msgServer) OpenContractValidate(ctx cosmos.Context, msg *types.MsgOpenCo
 			return sdkerrors.Wrapf(types.ErrOpenContractMismatchRate, "mismatch of rate*duration and deposit: %d * %d != %d", msg.Rate, msg.Duration, msg.Deposit.Int64())
 		}
 	case types.ContractType_PayAsYouGo:
-		if msg.Rate != provider.SubscriptionRate {
+		if msg.Rate != provider.PayAsYouGoRate {
 			return sdkerrors.Wrapf(types.ErrOpenContractMismatchRate, "pay-as-you-go %d (client) vs %d (provider)", msg.Rate, provider.PayAsYouGoRate)
 		}
 	default:


### PR DESCRIPTION
fixes `'failed to execute message; message index: 0: pay-as-you-go 20 (client) vs
  20 (provider): mismatch contract rate'`