### PR TITLE
allow chain names, passed via the path to be used as the internal hos…

### DIFF
--- a/common/chain.go
+++ b/common/chain.go
@@ -13,25 +13,29 @@ type (
 const (
 	EmptyChain Chain = iota
 	BaseChain
+	StarWarsChain
 	BTCChain
 	ETHChain
 )
 
 var ChainLookup = map[string]int32{
-	"unknown":       0,
-	"arkeo-mainnet": 1,
-	"btc-mainnet":   2,
-	"eth-mainnet":   3,
+	"unknown":                0,
+	"swapi.dev":              1, // star wars API for development purposes
+	"arkeo-mainnet-fullnode": 2,
+	"btc-mainnet-fullnode":   3,
+	"eth-mainnet-fullnode":   4,
 }
 
 func (c Chain) String() string {
 	switch c {
 	case BaseChain:
-		return "arkeo-mainnet"
+		return "arkeo-mainnet-fullnode"
 	case BTCChain:
-		return "btc-mainnet"
+		return "btc-mainnet-fullnode"
 	case ETHChain:
-		return "eth-mainnet"
+		return "eth-mainnet-fullnode"
+	case StarWarsChain:
+		return "swapi.dev"
 	default:
 		return "unknown"
 	}

--- a/common/chain_test.go
+++ b/common/chain_test.go
@@ -9,11 +9,11 @@ type ChainSuite struct{}
 var _ = Suite(&ChainSuite{})
 
 func (s ChainSuite) TestChain(c *C) {
-	chn, err := NewChain("btc-mainnet")
+	chn, err := NewChain("btc-mainnet-fullnode")
 	c.Assert(err, IsNil)
 	c.Check(chn.Equals(BTCChain), Equals, true)
 	c.Check(chn.IsEmpty(), Equals, false)
-	c.Check(chn.String(), Equals, "btc-mainnet")
+	c.Check(chn.String(), Equals, "btc-mainnet-fullnode")
 
 	_, err = NewChain("B") // invalid
 	c.Assert(err, NotNil)

--- a/sentinel/claim_store_test.go
+++ b/sentinel/claim_store_test.go
@@ -27,7 +27,7 @@ func (s *ClaimStoreSuite) TestStore(c *C) {
 
 	pk1 := types.GetRandomPubKey()
 	pk2 := types.GetRandomPubKey()
-	chain, err := common.NewChain("btc-mainnet")
+	chain, err := common.NewChain("btc-mainnet-fullnode")
 	c.Assert(err, IsNil)
 	claim := NewClaim(pk1, chain, pk2, 30, 10, "signature")
 

--- a/sentinel/sentinel.go
+++ b/sentinel/sentinel.go
@@ -36,9 +36,9 @@ func NewProxy(config conf.Configuration) Proxy {
 }
 
 // Serve a reverse proxy for a given url
-func (p Proxy) serveReverseProxy(w http.ResponseWriter, r *http.Request) {
+func (p Proxy) serveReverseProxy(w http.ResponseWriter, r *http.Request, host string) {
 	// parse the url
-	url, _ := url.Parse(p.Config.ProxyHost)
+	url, _ := url.Parse(fmt.Sprintf("http://%s", host))
 
 	// create the reverse proxy
 	proxy := httputil.NewSingleHostReverseProxy(url)
@@ -55,10 +55,11 @@ func (p Proxy) handleRequestAndRedirect(w http.ResponseWriter, r *http.Request) 
 	r.URL.RawQuery = values.Encode()
 
 	parts := strings.Split(r.URL.Path, "/")
+	host := parts[1]
 	parts = append(parts[:1], parts[1+1:]...)
 	r.URL.Path = strings.Join(parts, "/")
 
-	p.serveReverseProxy(w, r)
+	p.serveReverseProxy(w, r, host)
 }
 
 func (p Proxy) handleMetadata(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
this is a simple change buy allows sentinel to be the proxy itself instead of relaying on nginx to proxy to various hosts