### PR TITLE
add open claims endpoint

### DIFF
--- a/common/chain.go
+++ b/common/chain.go
@@ -12,8 +12,8 @@ type (
 
 const (
 	EmptyChain Chain = iota
-	BaseChain
 	StarWarsChain
+	BaseChain
 	BTCChain
 	ETHChain
 )
@@ -44,7 +44,7 @@ func (c Chain) String() string {
 // ChainNetwork is to indicate which chain environment
 type ChainNetwork uint8
 
-// NewChain create a new Chain and default the siging_algo to Secp256k1
+// NewChain create a new Chain
 func NewChain(chainID string) (Chain, error) {
 	chain := ChainLookup[strings.ToLower(chainID)]
 	if chain == 0 {

--- a/common/chain_test.go
+++ b/common/chain_test.go
@@ -15,6 +15,12 @@ func (s ChainSuite) TestChain(c *C) {
 	c.Check(chn.IsEmpty(), Equals, false)
 	c.Check(chn.String(), Equals, "btc-mainnet-fullnode")
 
+	chn, err = NewChain("swapi.dev")
+	c.Assert(err, IsNil)
+	c.Check(chn.Equals(StarWarsChain), Equals, true)
+	c.Check(chn.IsEmpty(), Equals, false)
+	c.Check(chn.String(), Equals, "swapi.dev")
+
 	_, err = NewChain("B") // invalid
 	c.Assert(err, NotNil)
 }

--- a/sentinel/event_stream.go
+++ b/sentinel/event_stream.go
@@ -104,7 +104,11 @@ func (p Proxy) EventListener(host string) {
 					if !isMyPubKey(evt.Contract.ProviderPubKey) {
 						continue
 					}
-					newClaim := NewClaim(evt.Contract.ProviderPubKey, evt.Contract.Chain, evt.Contract.Delegate, evt.Contract.Nonce, evt.Contract.Height, "")
+					spender := evt.Contract.Delegate
+					if spender.IsEmpty() {
+						spender = evt.Contract.Client
+					}
+					newClaim := NewClaim(evt.Contract.ProviderPubKey, evt.Contract.Chain, spender, evt.Contract.Nonce, evt.Contract.Height, "")
 					currClaim, err := p.ClaimStore.Get(newClaim.Key())
 					if err != nil {
 						logger.Error("failed to get claim", "error", err)
@@ -149,7 +153,11 @@ func (p Proxy) EventListener(host string) {
 			if !isMyPubKey(evt.Contract.ProviderPubKey) {
 				continue
 			}
-			newClaim := NewClaim(evt.Contract.ProviderPubKey, evt.Contract.Chain, evt.Contract.Delegate, evt.Contract.Nonce, evt.Contract.Height, "")
+			spender := evt.Contract.Delegate
+			if spender.IsEmpty() {
+				spender = evt.Contract.Client
+			}
+			newClaim := NewClaim(evt.Contract.ProviderPubKey, evt.Contract.Chain, spender, evt.Contract.Nonce, evt.Contract.Height, "")
 			currClaim, err := p.ClaimStore.Get(newClaim.Key())
 			if err != nil {
 				logger.Error("failed to get claim", "error", err)

--- a/sentinel/event_stream.go
+++ b/sentinel/event_stream.go
@@ -110,7 +110,7 @@ func (p Proxy) EventListener(host string) {
 						logger.Error("failed to get claim", "error", err)
 						continue
 					}
-					if currClaim.Nonce == newClaim.Height {
+					if currClaim.Nonce == newClaim.Nonce && currClaim.Height == newClaim.Height {
 						currClaim.Claimed = true
 						if err := p.ClaimStore.Set(currClaim); err != nil {
 							logger.Error("failed to set claimed", "error", err)
@@ -155,7 +155,7 @@ func (p Proxy) EventListener(host string) {
 				logger.Error("failed to get claim", "error", err)
 				continue
 			}
-			if currClaim.Nonce == newClaim.Height {
+			if currClaim.Nonce == newClaim.Nonce && currClaim.Height == newClaim.Height {
 				currClaim.Claimed = true
 				if err := p.ClaimStore.Set(currClaim); err != nil {
 					logger.Error("failed to set claimed", "error", err)

--- a/sentinel/event_stream.go
+++ b/sentinel/event_stream.go
@@ -131,7 +131,12 @@ func (p Proxy) EventListener(host string) {
 			if !isMyPubKey(evt.Contract.ProviderPubKey) {
 				continue
 			}
-			key := p.MemStore.Key(evt.Contract.ProviderPubKey.String(), evt.Contract.Chain.String(), evt.Contract.Delegate.String())
+
+			spender := evt.Contract.Delegate
+			if spender.IsEmpty() {
+				spender = evt.Contract.Client
+			}
+			key := p.MemStore.Key(evt.Contract.ProviderPubKey.String(), evt.Contract.Chain.String(), spender.String())
 			p.MemStore.Put(key, evt.Contract)
 		case result := <-closeContractOut:
 			evt, err := parseCloseContract(convertEvent("close_contract", result.Events))
@@ -142,7 +147,12 @@ func (p Proxy) EventListener(host string) {
 			if !isMyPubKey(evt.Contract.ProviderPubKey) {
 				continue
 			}
-			key := p.MemStore.Key(evt.Contract.ProviderPubKey.String(), evt.Contract.Chain.String(), evt.Contract.Delegate.String())
+
+			spender := evt.Contract.Delegate
+			if spender.IsEmpty() {
+				spender = evt.Contract.Client
+			}
+			key := p.MemStore.Key(evt.Contract.ProviderPubKey.String(), evt.Contract.Chain.String(), spender.String())
 			p.MemStore.Put(key, evt.Contract)
 		case result := <-claimContractOut:
 			evt, err := parseClaimContractIncome(convertEvent("contract_settlement", result.Events))

--- a/sentinel/memstore.go
+++ b/sentinel/memstore.go
@@ -94,7 +94,6 @@ func (k *MemStore) fetchContract(key string) (types.Contract, error) {
 		return contract, err
 	}
 
-	fmt.Println("Foo 2")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		fmt.Println(err)

--- a/sentinel/sentinel.go
+++ b/sentinel/sentinel.go
@@ -86,7 +86,7 @@ func (p Proxy) handleOpenClaims(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if contract.IsClose(p.MemStore.GetHeight()) {
-			p.ClaimStore.Remove(claim.Key()) // clear expired
+			_ = p.ClaimStore.Remove(claim.Key()) // clear expired
 			fmt.Println("expired")
 			continue
 		}


### PR DESCRIPTION
adds a new API endpoint to allow providers to pull unclaim rewards list from their own node. These can then be broadcast to the chain via `arkeod tx arkeo claim-contract-income` command
