### PR TITLE
fix panic

### DIFF
--- a/sentinel/memstore.go
+++ b/sentinel/memstore.go
@@ -112,10 +112,10 @@ func (k *MemStore) fetchContract(key string) (types.Contract, error) {
 		return contract, err
 	}
 
-	if data.Contract.Deposit == nil {
+	if data.Contract.Deposit.IsNil() {
 		data.Contract.Deposit = cosmos.ZeroInt()
 	}
-	if data.Contract.Paid == nil {
+	if data.Contract.Paid.IsNil() {
 		data.Contract.Paid = cosmos.ZeroInt()
 	}
 

--- a/sentinel/memstore.go
+++ b/sentinel/memstore.go
@@ -112,6 +112,13 @@ func (k *MemStore) fetchContract(key string) (types.Contract, error) {
 		return contract, err
 	}
 
+	if data.Contract.Deposit == nil {
+		data.Contract.Deposit = cosmos.ZeroInt()
+	}
+	if data.Contract.Paid == nil {
+		data.Contract.Paid = cosmos.ZeroInt()
+	}
+
 	contract.ProviderPubKey = data.Contract.ProviderPubKey
 	contract.Chain = data.Contract.Chain
 	contract.Client = data.Contract.Client

--- a/sentinel/sentinel.go
+++ b/sentinel/sentinel.go
@@ -63,7 +63,7 @@ func (p Proxy) handleRequestAndRedirect(w http.ResponseWriter, r *http.Request) 
 		// add username/password to request
 		host = fmt.Sprintf("thorchain:password@%s:8332", host)
 	case "arkeo-mainnet-fullnode":
-		host = fmt.Sprintf("arkeo:1317", host)
+		host = "arkeo:1317"
 	}
 
 	p.serveReverseProxy(w, r, host)


### PR DESCRIPTION
```
10.1.196.177 - - [03/Jan/2023:22:49:34 +0000] "GET /metadata.json HTTP/1.1" 200 594
I[2023-01-03|22:49:35.288] New height detected                          height=563112
10.1.196.177 - - [03/Jan/2023:22:49:38 +0000] "GET /claim/arkeopub1addwnpepqtrc0rrpkwn2esula68zl3dvqqfxfjhr5dyfxy3uq97dssntrq8twhy9nvu/btc-mainnet-fullnode/arkeopub1addwnpepq2tjwwcpqwswatymx7uw3q75sqhljmp0qw3pz2fvnavkv7k2jvknq9k9lr0 HTTP/1.1" 200 90
10.1.196.177 - - [03/Jan/2023:22:49:38 +0000] "GET /contract/arkeopub1addwnpepqtrc0rrpkwn2esula68zl3dvqqfxfjhr5dyfxy3uq97dssntrq8twhy9nvu/btc-mainnet-fullnode/arkeopub1addwnpepq2tjwwcpqwswatymx7uw3q75sqhljmp0qw3pz2fvnavkv7k2jvknq9k9lr0 HTTP/1.1" 200 273
I[2023-01-03|22:49:40.565] New height detected                          height=563113
Paid Tier
2023/01/03 22:49:40 http: panic serving 10.1.196.177:41832: runtime error: invalid memory address or nil pointer dereference
goroutine 62 [running]:
net/http.(*conn).serve.func1()
    /usr/local/go/src/net/http/server.go:1825 +0xbf
panic({0x1b13020, 0x3690b20})
    /usr/local/go/src/runtime/panic.go:844 +0x258
math/big.(*Int).Cmp(0xc000ebcfc0?, 0xc0001c4b90?)
    /usr/local/go/src/math/big/int.go:328 +0x22
cosmossdk.io/math.lt(...)
    /go/pkg/mod/cosmossdk.io/math@v1.0.0-beta.3/int.go:24
cosmossdk.io/math.Int.LT(...)
    /go/pkg/mod/cosmossdk.io/math@v1.0.0-beta.3/int.go:220
arkeo/sentinel.Proxy.paidTier({{{{0xc00005a028, 0x3}, {0xc00005a038, 0x3}, {0xc00005a04c, 0x3}, {0xc00005a059, 0x3}, {0x1daa796, 0x4}, ...}, ...}, ...}, ...)
    /app/sentinel/auth.go:196 +0xa65
arkeo/sentinel.Proxy.auth.func1({0x276f5f0, 0xc0013962a0}, 0xc000576000)
    /app/sentinel/auth.go:99 +0x25b
net/http.HandlerFunc.ServeHTTP(0x1a70720?, {0x276f5f0?, 0xc0013962a0?}, 0xc000e9e070?)
    /usr/local/go/src/net/http/server.go:2084 +0x2f
net/http.(*ServeMux).ServeHTTP(0xc001e5a01b?, {0x276f5f0, 0xc0013962a0}, 0xc000576000)
    /usr/local/go/src/net/http/server.go:2462 +0x149
net/http.serverHandler.ServeHTTP({0x2759c60?}, {0x276f5f0, 0xc0013962a0}, 0xc000576000)
    /usr/local/go/src/net/http/server.go:2916 +0x43b
net/http.(*conn).serve(0xc001541360, {0x2770d98, 0xc0001479b0})
    /usr/local/go/src/net/http/server.go:1966 +0x5d7
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:3071 +0x4db
    ```